### PR TITLE
Add travis ci and better tomcat naming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+services:
+  - docker
+
+env:
+    global:
+       - IMAGE_NAME=aksw/agdistis-demo
+
+before_script:
+    - docker pull "$IMAGE_NAME" || true
+
+script:
+    - docker run --rm -it -v $(pwd):/project maven mvn package -f /project
+    - docker build --pull --cache-from "$IMAGE_NAME" -t "$IMAGE_NAME" .
+
+before_deploy:
+    - docker login -u "$DOCKER_USERNAME" -p "$DOCKER_PASSWORD"
+    - docker tag "$IMAGE_NAME" "${IMAGE_NAME}:latest"
+
+deploy:
+  provider: script
+  script: docker push "${IMAGE_NAME}:latest"
+  on:
+    branch: master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM tomcat:8-jre8
 
 # ADD war file
-ADD target/mag-1.0.0-BUILD-SNAPSHOT.war webapps/mag.war
+ADD target/mag-1.0.0-BUILD-SNAPSHOT.war webapps/mag-demo.war


### PR DESCRIPTION
Once setup travis builds the master branch and uploads a freshly baked
docker image to aksw/agdistis-demo

Also use the path <tomcat>/mag-demo instead of /mag for clarification

Signed-off-by: Paul Spooren <mail@aparcar.org>